### PR TITLE
Add competitor comparison mode

### DIFF
--- a/agents/mock_data.py
+++ b/agents/mock_data.py
@@ -1,7 +1,7 @@
 """
 Mock data for --dry-run mode.
 
-Provides a realistic AnalysisResult for SAP SE so the full pipeline
+Provides realistic AnalysisResult instances so the full pipeline
 (report generation, DOCX output, styling) can be tested without an API key.
 """
 
@@ -115,3 +115,108 @@ SAP_MOCK = AnalysisResult(
         "Talent competition for AI and cloud engineers increasing R&D cost base",
     ],
 )
+
+
+ZALANDO_MOCK = AnalysisResult(
+    executive_summary=(
+        "Zalando SE is Europe's leading online fashion and lifestyle platform, operating "
+        "in 25 markets with over 50 million active customers. The company generated EUR 10.1 "
+        "billion in gross merchandise volume (GMV) in 2024, up 3.5% year-over-year. Zalando is "
+        "transitioning from a pure retailer to a platform ecosystem model (ZEOS), enabling third-party "
+        "brands to leverage its logistics, payments, and customer base as a service."
+    ),
+    company_overview=(
+        "Zalando SE was founded in 2008 in Berlin by Robert Gentz and David Schneider, initially "
+        "as an online shoe retailer. Today it employs approximately 17,000 people and operates "
+        "across 25 European markets. Its product portfolio spans fashion, beauty, accessories, "
+        "and lifestyle categories, offering over 6,000 brands. Zalando operates its own logistics "
+        "network with 12 fulfillment centers across Europe, plus a growing partner fulfillment program."
+    ),
+    market_position=(
+        "Zalando holds approximately 11% of the European online fashion market and is the largest "
+        "dedicated fashion e-commerce platform on the continent. Its competitive moat stems from "
+        "brand density (6,000+ brands), logistics infrastructure (same-day/next-day delivery in "
+        "key markets), and a strong mobile-first user experience. The ZEOS platform play aims to "
+        "position Zalando as the operating system for European fashion commerce."
+    ),
+    swot=SWOTAnalysis(
+        strengths=[
+            "Largest European online fashion platform with 50M+ active customers",
+            "Proprietary logistics network enabling fast delivery across 25 markets",
+            "Strong brand partnerships with 6,000+ fashion and lifestyle labels",
+            "Successful private label portfolio (Zign, YOURTURN) driving margin expansion",
+        ],
+        weaknesses=[
+            "Profitability remains thin — adjusted EBIT margin around 2-3% historically",
+            "Heavy dependence on promotional pricing and discounts to drive volume",
+            "Limited presence outside Europe — no meaningful US or Asia business",
+            "Returns rate of 40-50% in fashion significantly impacts unit economics",
+        ],
+        opportunities=[
+            "ZEOS platform-as-a-service model creating new high-margin revenue streams",
+            "Connected retail bridging online and offline for brand partners",
+            "Pre-owned fashion and recommerce segment growing 30%+ annually",
+            "AI-powered personalization improving conversion rates and reducing returns",
+        ],
+        threats=[
+            "Shein and Temu offering ultra-low-price fashion undercutting European players",
+            "Amazon Fashion investing heavily in European fashion infrastructure",
+            "About You (acquired by Zalando) integration risks and execution challenges",
+            "Consumer spending pressures from inflation reducing discretionary fashion spend",
+        ],
+    ),
+    top_competitors=[
+        Competitor(
+            name="ASOS plc",
+            overview="UK-based online fashion retailer targeting 20-somethings across Europe and globally.",
+            key_strength="Strong brand identity with younger demographics and own-brand margin advantage",
+            key_weakness="Struggling with profitability and operational restructuring since 2023",
+        ),
+        Competitor(
+            name="Amazon Fashion",
+            overview="Amazon's fashion vertical leveraging its massive logistics network and Prime membership base.",
+            key_strength="Unmatched logistics scale, Prime flywheel, and limitless category expansion",
+            key_weakness="Perceived as less curated and fashion-forward compared to dedicated platforms",
+        ),
+        Competitor(
+            name="About You",
+            overview="Hamburg-based fashion platform recently acquired by Zalando, previously a direct competitor.",
+            key_strength="Strong personalization engine and younger customer demographic in DACH region",
+            key_weakness="Persistent losses and now being integrated into Zalando ecosystem",
+        ),
+        Competitor(
+            name="H&M Group (Online)",
+            overview="Swedish fast-fashion giant with growing e-commerce operations across 60+ markets.",
+            key_strength="Massive physical store network complementing online presence with omnichannel strategy",
+            key_weakness="Brand perception challenges around sustainability and fast-fashion criticism",
+        ),
+    ],
+    key_trends=[
+        "Platform business models replacing pure retail — Zalando ZEOS, Farfetch, marketplace shifts",
+        "AI-driven personalization and virtual try-on reducing return rates by 15-20%",
+        "Recommerce and circular fashion growing as sustainability regulation tightens",
+        "Social commerce integration (TikTok Shop, Instagram Shopping) reshaping discovery",
+        "Quick commerce pressure — consumer expectations shifting to same-day delivery",
+        "Direct-to-consumer brands bypassing platforms with Shopify-powered storefronts",
+        "EU Digital Services Act and sustainability reporting mandates increasing compliance costs",
+    ],
+    investment_thesis=(
+        "Zalando's transition to a platform model via ZEOS has the potential to unlock significantly "
+        "higher margins than its traditional retail business. With 50M+ active customers and a dominant "
+        "logistics network, it is well positioned to become the Shopify of European fashion. The About You "
+        "acquisition adds scale, but integration execution remains the key near-term risk."
+    ),
+    risk_factors=[
+        "ZEOS platform adoption by brands slower than projected, limiting margin uplift",
+        "Shein/Temu price competition eroding market share in price-sensitive segments",
+        "About You integration consuming management attention and creating operational friction",
+        "Fashion returns rate (40-50%) structurally limiting profitability improvement",
+        "European consumer spending downturn reducing discretionary fashion purchases",
+    ],
+)
+
+
+COMPARISON_MOCKS = {
+    "SAP SE": SAP_MOCK,
+    "Zalando SE": ZALANDO_MOCK,
+}

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -9,9 +9,10 @@ Pipeline:
 
 import anthropic
 from .researcher import ResearchAgent
-from .analyst import AnalysisAgent
+from .analyst import AnalysisAgent, AnalysisResult
 from utils.report_generator import generate_docx_report
 from utils.pdf_report_generator import generate_pdf_report
+from utils.comparison_report import generate_comparison_report
 
 
 class MarketResearchOrchestrator:
@@ -88,4 +89,52 @@ class MarketResearchOrchestrator:
         print(f"  Done! Open the report in Microsoft Word or LibreOffice.")
         print(f"{'='*60}\n")
 
+        return report_path
+
+    def run_comparison(self, companies: list[str]) -> str:
+        """
+        Run the pipeline for multiple companies and generate a comparison report.
+
+        Args:
+            companies: List of 2-3 company names to compare
+
+        Returns:
+            Absolute path to the generated comparison DOCX report
+        """
+        analyses = []
+        total = len(companies)
+
+        for idx, company in enumerate(companies, 1):
+            print(f"\n{'='*60}")
+            print(f"  Analyzing {idx}/{total}: {company}")
+            print(f"{'='*60}\n")
+
+            print("[1/2]  ResearchAgent: Gathering web intelligence...")
+            research_brief = self._researcher.research(company)
+            word_count = len(research_brief.split())
+            print(f"       Research complete — {word_count} words gathered\n")
+
+            print("[2/2]  AnalysisAgent: Structuring analysis & SWOT...\n")
+            analysis = self._analyst.analyze(company, research_brief)
+            print(f"       Analysis complete")
+            print(f"         Competitors: {len(analysis.top_competitors)}")
+            print(f"         Trends: {len(analysis.key_trends)}\n")
+            analyses.append(analysis)
+
+        print(f"\n{'='*60}")
+        print(f"  Generating comparison report...")
+        print(f"{'='*60}\n")
+
+        report_path = generate_comparison_report(companies, analyses, self.output_dir)
+        print(f"       Report saved:\n       {report_path}\n")
+
+        return report_path
+
+    def run_comparison_with_mock(
+        self, companies: list[str], analyses: list[AnalysisResult],
+    ) -> str:
+        """Run comparison with pre-built analysis data (for --dry-run)."""
+        print(f"\n  Generating comparison report for: {', '.join(companies)}")
+        report_path = generate_comparison_report(companies, analyses, self.output_dir)
+        print(f"       Report saved:\n       {report_path}\n")
         return report_path

--- a/main.py
+++ b/main.py
@@ -35,6 +35,12 @@ Examples:
         help='Company name to research (e.g. "SAP SE", "Zalando", "Tesla")',
     )
     parser.add_argument(
+        "--compare",
+        nargs="+",
+        metavar="COMPANY",
+        help="Compare 2-3 companies side-by-side (e.g., --compare 'SAP SE' 'Zalando SE')",
+    )
+    parser.add_argument(
         "--output",
         default="output",
         help="Directory to save the generated report (default: ./output)",
@@ -57,41 +63,62 @@ def main():
     load_dotenv()
     args = parse_args()
 
+    if args.compare and len(args.compare) < 2:
+        print("Error: --compare requires at least 2 companies.")
+        sys.exit(1)
+    if args.compare and len(args.compare) > 3:
+        print("Error: --compare supports at most 3 companies.")
+        sys.exit(1)
+
     # -----------------------------------------------------------------------
     # Dry-run: generate report from mock data, no API key required
     # -----------------------------------------------------------------------
     if args.dry_run:
-        from agents.mock_data import SAP_MOCK
-        from utils.report_generator import generate_docx_report
-        from utils.pdf_report_generator import generate_pdf_report
+        from agents.mock_data import SAP_MOCK, COMPARISON_MOCKS
 
-        company = args.company or "SAP SE"
-        fmt = args.format
-        print(f"\n{'='*60}")
-        print(f"  DRY RUN — using mock data for: {company}")
-        print(f"{'='*60}\n")
-        print("[1/3]  ResearchAgent:  skipped (dry-run)\n")
-        print("[2/3]  AnalysisAgent:  skipped (dry-run)\n")
-        print(f"[3/3]  ReportGenerator: building {fmt.upper()}...\n")
+        if args.compare:
+            companies = args.compare
+            analyses = [COMPARISON_MOCKS.get(c, SAP_MOCK) for c in companies]
+            print(f"\n{'='*60}")
+            print(f"  DRY RUN — COMPETITOR COMPARISON")
+            print(f"  Companies: {', '.join(companies)}")
+            print(f"{'='*60}\n")
 
-        generator = generate_pdf_report if fmt == "pdf" else generate_docx_report
-        report_path = generator(
-            company=company,
-            analysis=SAP_MOCK,
-            output_dir=args.output,
-        )
-        print(f"       ✓ Report saved:\n       {report_path}\n")
+            orch = MarketResearchOrchestrator(output_dir=args.output)
+            report_path = orch.run_comparison_with_mock(companies, analyses)
+        else:
+            from utils.report_generator import generate_docx_report
+            from utils.pdf_report_generator import generate_pdf_report
+
+            company = args.company or "SAP SE"
+            fmt = args.format
+            print(f"\n{'='*60}")
+            print(f"  DRY RUN — using mock data for: {company}")
+            print(f"{'='*60}\n")
+            print("[1/3]  ResearchAgent:  skipped (dry-run)\n")
+            print("[2/3]  AnalysisAgent:  skipped (dry-run)\n")
+            print(f"[3/3]  ReportGenerator: building {fmt.upper()}...\n")
+
+            generator = generate_pdf_report if fmt == "pdf" else generate_docx_report
+            report_path = generator(
+                company=company,
+                analysis=SAP_MOCK,
+                output_dir=args.output,
+            )
+
+        print(f"       Report saved:\n       {report_path}\n")
         print(f"{'='*60}")
-        print("  Open the .docx file in Word or LibreOffice to preview.")
+        print("  Open the report in Word or LibreOffice to preview.")
         print(f"{'='*60}\n")
         return
 
     # -----------------------------------------------------------------------
     # Normal run: requires API key and company name
     # -----------------------------------------------------------------------
-    if not args.company:
+    if not args.company and not args.compare:
         print("Error: please provide a company name, e.g.:")
         print('  python3 main.py "SAP SE"')
+        print('  python3 main.py --compare "SAP SE" "Zalando SE"')
         print("  python3 main.py --dry-run   (no API key needed)")
         sys.exit(1)
 
@@ -111,7 +138,10 @@ def main():
     )
 
     try:
-        report_path = orchestrator.run(args.company)
+        if args.compare:
+            report_path = orchestrator.run_comparison(args.compare)
+        else:
+            report_path = orchestrator.run(args.company)
         print(f"\nReport: {report_path}")
     except KeyboardInterrupt:
         print("\n\nAborted by user.")

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,147 @@
+"""Tests for competitor comparison mode."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agents.analyst import AnalysisResult, SWOTAnalysis, Competitor
+from agents.mock_data import SAP_MOCK, ZALANDO_MOCK, COMPARISON_MOCKS
+from utils.comparison_report import generate_comparison_report
+
+
+@pytest.fixture
+def minimal_analysis():
+    return AnalysisResult(
+        executive_summary="Summary.",
+        company_overview="Overview.",
+        market_position="Position.",
+        swot=SWOTAnalysis(
+            strengths=["S1"], weaknesses=["W1"],
+            opportunities=["O1"], threats=["T1"],
+        ),
+        top_competitors=[
+            Competitor(name="Rival", overview="Desc",
+                       key_strength="Strong", key_weakness="Weak"),
+        ],
+        key_trends=["Trend 1"],
+        investment_thesis="Thesis.",
+        risk_factors=["Risk 1"],
+    )
+
+
+class TestComparisonMocks:
+    def test_has_sap(self):
+        assert "SAP SE" in COMPARISON_MOCKS
+
+    def test_has_zalando(self):
+        assert "Zalando SE" in COMPARISON_MOCKS
+
+    def test_zalando_mock_valid(self):
+        assert isinstance(ZALANDO_MOCK, AnalysisResult)
+        assert len(ZALANDO_MOCK.top_competitors) >= 3
+        assert len(ZALANDO_MOCK.swot.strengths) >= 3
+        assert len(ZALANDO_MOCK.key_trends) >= 5
+
+    def test_zalando_mock_content(self):
+        assert "Zalando" in ZALANDO_MOCK.company_overview
+        assert len(ZALANDO_MOCK.executive_summary) > 100
+
+
+class TestComparisonReport:
+    def test_generates_docx(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["A", "B"], [minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+        assert path.endswith(".docx")
+
+    def test_filename_format(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["Alpha Corp", "Beta Inc"], [minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        name = os.path.basename(path)
+        assert "alpha_corp" in name
+        assert "beta_inc" in name
+        assert "_vs_" in name
+
+    def test_three_companies(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["A", "B", "C"],
+            [minimal_analysis, minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+
+    def test_with_real_mocks(self, tmp_path):
+        path = generate_comparison_report(
+            ["SAP SE", "Zalando SE"],
+            [SAP_MOCK, ZALANDO_MOCK],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+        assert os.path.getsize(path) > 10000
+
+    def test_creates_directory(self, tmp_path, minimal_analysis):
+        out = str(tmp_path / "nested" / "dir")
+        path = generate_comparison_report(
+            ["X", "Y"], [minimal_analysis, minimal_analysis],
+            output_dir=out,
+        )
+        assert os.path.isfile(path)
+
+
+class TestOrchestratorComparison:
+    def test_mock_comparison(self, tmp_path):
+        from agents.orchestrator import MarketResearchOrchestrator
+        orch = MarketResearchOrchestrator(output_dir=str(tmp_path))
+        path = orch.run_comparison_with_mock(
+            ["SAP SE", "Zalando SE"],
+            [SAP_MOCK, ZALANDO_MOCK],
+        )
+        assert os.path.isfile(path)
+
+    @patch("agents.orchestrator.ResearchAgent")
+    @patch("agents.orchestrator.AnalysisAgent")
+    def test_comparison_calls_agents(self, mock_analyst_cls, mock_researcher_cls, tmp_path):
+        from agents.orchestrator import MarketResearchOrchestrator
+
+        mock_researcher = MagicMock()
+        mock_researcher.research.return_value = "Research data"
+        mock_researcher_cls.return_value = mock_researcher
+
+        mock_analyst = MagicMock()
+        mock_analyst.analyze.return_value = SAP_MOCK
+        mock_analyst_cls.return_value = mock_analyst
+
+        orch = MarketResearchOrchestrator(output_dir=str(tmp_path))
+        path = orch.run_comparison(["Company A", "Company B"])
+
+        assert mock_researcher.research.call_count == 2
+        assert mock_analyst.analyze.call_count == 2
+        assert os.path.isfile(path)
+
+
+class TestComparisonCLI:
+    def test_dry_run_compare(self, tmp_path):
+        result = subprocess.run(
+            [sys.executable, "main.py", "--dry-run",
+             "--compare", "SAP SE", "Zalando SE",
+             "--output", str(tmp_path)],
+            capture_output=True, text=True,
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+        )
+        assert result.returncode == 0
+        assert "COMPARISON" in result.stdout
+
+    def test_compare_needs_two(self):
+        result = subprocess.run(
+            [sys.executable, "main.py", "--dry-run", "--compare", "OnlyOne"],
+            capture_output=True, text=True,
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+        )
+        assert result.returncode != 0

--- a/utils/comparison_report.py
+++ b/utils/comparison_report.py
@@ -1,0 +1,349 @@
+"""
+Comparison Report Generator — Side-by-side competitor comparison DOCX report.
+
+Takes multiple AnalysisResult objects and produces a single report with
+SWOT comparison matrices, competitor overlap tables, and trend analysis.
+"""
+
+import os
+from datetime import datetime
+from docx import Document
+from docx.shared import Inches, Pt, RGBColor
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+from agents.analyst import AnalysisResult
+
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+COLOR_DARK = RGBColor(0x1A, 0x37, 0x6C)
+COLOR_ACCENT = RGBColor(0x2E, 0x6D, 0xB4)
+COLOR_WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+COLOR_LIGHT_BG = "F0F5FF"
+COLOR_ALT_BG = "FFFFFF"
+
+COMPANY_COLORS = ["1A6C3C", "1A376C", "6C1A3C"]
+
+SWOT_LABELS = [
+    ("STRENGTHS", "1D7A4A", "F0FFF4"),
+    ("WEAKNESSES", "92600D", "FFFBF0"),
+    ("OPPORTUNITIES", "0D666B", "F0FFFF"),
+    ("THREATS", "9B1C1C", "FFF5F5"),
+]
+
+
+def _set_bg(cell, color: str):
+    tc = cell._tc
+    tcPr = tc.get_or_add_tcPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), color)
+    tcPr.append(shd)
+
+
+def _heading(doc, text, level=1):
+    para = doc.add_heading(text, level=level)
+    run = para.runs[0]
+    run.font.color.rgb = COLOR_DARK
+    run.font.bold = True
+    if level == 1:
+        run.font.size = Pt(16)
+    elif level == 2:
+        run.font.size = Pt(13)
+        run.font.color.rgb = COLOR_ACCENT
+    para.paragraph_format.space_before = Pt(14)
+    para.paragraph_format.space_after = Pt(4)
+
+
+def _hr(doc):
+    para = doc.add_paragraph()
+    pPr = para._p.get_or_add_pPr()
+    pBdr = OxmlElement("w:pBdr")
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), "6")
+    bottom.set(qn("w:space"), "1")
+    bottom.set(qn("w:color"), "2E6DB4")
+    pBdr.append(bottom)
+    pPr.append(pBdr)
+
+
+def _build_cover(doc, companies):
+    doc.add_paragraph()
+    doc.add_paragraph()
+
+    title = doc.add_paragraph()
+    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = title.add_run("COMPETITOR COMPARISON REPORT")
+    run.font.size = Pt(28)
+    run.font.bold = True
+    run.font.color.rgb = COLOR_DARK
+
+    doc.add_paragraph()
+
+    sub = doc.add_paragraph()
+    sub.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = sub.add_run(" vs ".join(companies))
+    run.font.size = Pt(20)
+    run.font.bold = True
+    run.font.color.rgb = COLOR_ACCENT
+
+    doc.add_paragraph()
+    doc.add_paragraph()
+
+    d = doc.add_paragraph()
+    d.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = d.add_run(f"Generated: {datetime.now().strftime('%B %d, %Y')}")
+    run.font.size = Pt(11)
+    run.font.color.rgb = RGBColor(0x6B, 0x72, 0x80)
+    run.font.italic = True
+
+    doc.add_page_break()
+
+
+def _text_comparison(doc, companies, analyses, field):
+    """Side-by-side table for a text field."""
+    cols = len(companies)
+    table = doc.add_table(rows=2, cols=cols)
+    table.style = "Table Grid"
+    table.autofit = False
+
+    w = Inches(6.0 / cols)
+    for col in table.columns:
+        for cell in col.cells:
+            cell.width = w
+
+    for i, name in enumerate(companies):
+        cell = table.rows[0].cells[i]
+        _set_bg(cell, COMPANY_COLORS[i % len(COMPANY_COLORS)])
+        p = cell.paragraphs[0]
+        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        r = p.add_run(name)
+        r.font.bold = True
+        r.font.size = Pt(10)
+        r.font.color.rgb = COLOR_WHITE
+
+    for i, a in enumerate(analyses):
+        cell = table.rows[1].cells[i]
+        _set_bg(cell, COLOR_LIGHT_BG if i % 2 == 0 else COLOR_ALT_BG)
+        r = cell.paragraphs[0].add_run(getattr(a, field, ""))
+        r.font.size = Pt(9.5)
+
+    doc.add_paragraph()
+
+
+def _list_comparison(doc, companies, analyses, field):
+    """Side-by-side table for a list field."""
+    cols = len(companies)
+    table = doc.add_table(rows=2, cols=cols)
+    table.style = "Table Grid"
+    table.autofit = False
+
+    w = Inches(6.0 / cols)
+    for col in table.columns:
+        for cell in col.cells:
+            cell.width = w
+
+    for i, name in enumerate(companies):
+        cell = table.rows[0].cells[i]
+        _set_bg(cell, COMPANY_COLORS[i % len(COMPANY_COLORS)])
+        p = cell.paragraphs[0]
+        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        r = p.add_run(name)
+        r.font.bold = True
+        r.font.size = Pt(10)
+        r.font.color.rgb = COLOR_WHITE
+
+    for i, a in enumerate(analyses):
+        cell = table.rows[1].cells[i]
+        _set_bg(cell, COLOR_LIGHT_BG if i % 2 == 0 else COLOR_ALT_BG)
+        for item in getattr(a, field, []):
+            para = cell.add_paragraph(style="List Bullet")
+            para.paragraph_format.left_indent = Inches(0.15)
+            r = para.add_run(item)
+            r.font.size = Pt(9)
+
+    doc.add_paragraph()
+
+
+def _swot_comparison(doc, companies, analyses):
+    """SWOT matrix comparison: one row per SWOT category, columns per company."""
+    swot_fields = ["strengths", "weaknesses", "opportunities", "threats"]
+
+    for (label, header_color, bg_color), field in zip(SWOT_LABELS, swot_fields):
+        cols = len(companies) + 1
+        table = doc.add_table(rows=2, cols=cols)
+        table.style = "Table Grid"
+        table.autofit = False
+
+        label_w = Inches(1.2)
+        col_w = Inches(4.8 / len(companies))
+
+        table.rows[0].cells[0].width = label_w
+        for i in range(1, cols):
+            table.rows[0].cells[i].width = col_w
+
+        # Header row
+        cell0 = table.rows[0].cells[0]
+        _set_bg(cell0, header_color)
+        p = cell0.paragraphs[0]
+        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        r = p.add_run(label)
+        r.font.bold = True
+        r.font.size = Pt(10)
+        r.font.color.rgb = COLOR_WHITE
+
+        for i, name in enumerate(companies):
+            cell = table.rows[0].cells[i + 1]
+            _set_bg(cell, COMPANY_COLORS[i % len(COMPANY_COLORS)])
+            p = cell.paragraphs[0]
+            p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            r = p.add_run(name)
+            r.font.bold = True
+            r.font.size = Pt(10)
+            r.font.color.rgb = COLOR_WHITE
+
+        # Content row
+        label_cell = table.rows[1].cells[0]
+        label_cell.width = label_w
+        _set_bg(label_cell, bg_color)
+
+        for i, a in enumerate(analyses):
+            cell = table.rows[1].cells[i + 1]
+            cell.width = col_w
+            _set_bg(cell, bg_color)
+            items = getattr(a.swot, field, [])
+            for item in items:
+                para = cell.add_paragraph(style="List Bullet")
+                para.paragraph_format.left_indent = Inches(0.1)
+                r = para.add_run(item)
+                r.font.size = Pt(9)
+
+        doc.add_paragraph()
+
+
+def _competitor_table(doc, companies, analyses):
+    """Combined competitor landscape table."""
+    headers = ["Analyzed Company", "Competitor", "Key Strength", "Key Weakness"]
+    rows_data = []
+    for name, a in zip(companies, analyses):
+        for comp in a.top_competitors[:3]:
+            rows_data.append((name, comp.name, comp.key_strength, comp.key_weakness))
+
+    table = doc.add_table(rows=1 + len(rows_data), cols=4)
+    table.style = "Table Grid"
+    table.autofit = False
+
+    widths = [Inches(1.3), Inches(1.3), Inches(1.8), Inches(1.8)]
+    for i, w in enumerate(widths):
+        for row in table.rows:
+            row.cells[i].width = w
+
+    for i, h in enumerate(headers):
+        cell = table.rows[0].cells[i]
+        _set_bg(cell, "1A376C")
+        p = cell.paragraphs[0]
+        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        r = p.add_run(h)
+        r.font.bold = True
+        r.font.size = Pt(10)
+        r.font.color.rgb = COLOR_WHITE
+
+    for idx, (company, comp_name, strength, weakness) in enumerate(rows_data):
+        row = table.rows[idx + 1]
+        bg = COLOR_LIGHT_BG if idx % 2 == 0 else COLOR_ALT_BG
+        for ci, val in enumerate([company, comp_name, strength, weakness]):
+            cell = row.cells[ci]
+            _set_bg(cell, bg)
+            r = cell.paragraphs[0].add_run(val)
+            r.font.size = Pt(9)
+            if ci <= 1:
+                r.font.bold = True
+
+    doc.add_paragraph()
+
+
+def generate_comparison_report(
+    companies: list[str],
+    analyses: list[AnalysisResult],
+    output_dir: str = "output",
+) -> str:
+    """
+    Generate a side-by-side competitor comparison DOCX report.
+
+    Args:
+        companies: List of company names
+        analyses:  Corresponding list of AnalysisResult objects
+        output_dir: Output directory
+
+    Returns:
+        Absolute path to the generated .docx file
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    doc = Document()
+
+    section = doc.sections[0]
+    section.top_margin = Inches(0.8)
+    section.bottom_margin = Inches(0.8)
+    section.left_margin = Inches(0.8)
+    section.right_margin = Inches(0.8)
+
+    style = doc.styles["Normal"]
+    style.font.size = Pt(10.5)
+    style.font.name = "Calibri"
+
+    _build_cover(doc, companies)
+
+    _heading(doc, "Executive Summary Comparison")
+    _hr(doc)
+    _text_comparison(doc, companies, analyses, "executive_summary")
+
+    _heading(doc, "Company Overviews")
+    _hr(doc)
+    _text_comparison(doc, companies, analyses, "company_overview")
+
+    _heading(doc, "Market Position")
+    _hr(doc)
+    _text_comparison(doc, companies, analyses, "market_position")
+
+    _heading(doc, "SWOT Comparison")
+    _hr(doc)
+    _swot_comparison(doc, companies, analyses)
+
+    _heading(doc, "Competitive Landscape")
+    _hr(doc)
+    _competitor_table(doc, companies, analyses)
+
+    _heading(doc, "Key Industry Trends")
+    _hr(doc)
+    _list_comparison(doc, companies, analyses, "key_trends")
+
+    _heading(doc, "Strategic Outlook")
+    _hr(doc)
+    _text_comparison(doc, companies, analyses, "investment_thesis")
+
+    _heading(doc, "Risk Factors")
+    _hr(doc)
+    _list_comparison(doc, companies, analyses, "risk_factors")
+
+    # Footer
+    doc.add_paragraph()
+    footer = doc.add_paragraph()
+    footer.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = footer.add_run(
+        f"Generated by Multi-Agent Market Research System  •  {datetime.now().strftime('%Y-%m-%d')}"
+    )
+    run.font.size = Pt(8.5)
+    run.font.italic = True
+    run.font.color.rgb = RGBColor(0x9C, 0xA3, 0xAF)
+
+    safe = "_vs_".join(c.lower().replace(" ", "_")[:20] for c in companies)
+    filename = f"competitor_comparison_{safe}_{datetime.now().strftime('%Y%m%d')}.docx"
+    filepath = os.path.join(output_dir, filename)
+    doc.save(filepath)
+
+    return os.path.abspath(filepath)


### PR DESCRIPTION
## Summary
- New `--compare` flag accepts 2-3 company names for side-by-side analysis
- Generates a single DOCX report with SWOT comparison matrices, executive summaries, market positions, competitor landscapes, trends, and risk factors
- Includes Zalando SE mock data for `--dry-run` testing
- Orchestrator runs research and analysis per company, then builds combined report

## Test plan
- [x] 13 new tests covering mock data, report generation, orchestrator, and CLI
- [x] Full test suite passes (70 tests)
- [x] `python main.py --dry-run --compare "SAP SE" "Zalando SE"` produces valid DOCX

Closes #2